### PR TITLE
Hotfix: need to specify path to dir contains .env

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -63,9 +63,9 @@ class Application extends Container implements ContainerInterface
         return $this->configBindings->getOrSet($input);
     }
 
-    public function bootConfig(string $configPath)
+    public function bootConfig(string $envPath, string $configPath)
     {
-        $dotenv = Dotenv::createImmutable(realpath(__DIR__.'/../../'));
+        $dotenv = Dotenv::createImmutable($envPath);
         $dotenv->load();
         $configFiles = (new Collection(scandir($configPath)))->reject(function($file) use ($configPath) {
             return $file === '.' || $file === '..' || (! file_exists($configPath .'/'. $file));


### PR DESCRIPTION
Update `bootConfig` function to accept path to directory containing `.env` file as well as the path to the `config` directory