### PR TITLE
v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ I'll be upfront: this project exists because I had a hankering to learn how mode
 
 # Installation
 
+The easiest way to get started quickly would be to clone the `PikaJew002/handrolled-project` repository and follow the few steps in the README (make empty directory, clone repo to directory, composer intall), then head back here and read on starting with `Usage` to learn more in-depth;
+
+Alternatively, install like so;
+
 You can install the Handrolled framework as a Composer package like so:
 
 ```
@@ -27,7 +31,9 @@ If you want more info on the dependencies that were used, check out the `compose
 To use this framework and get the most dope experience, I recommend using the Front Controller pattern;
 Simply put, all requests for your application should be routed through your `index.php` in your web root directory; I favor using a directory one level above your project root (`public_html`, `public`, etc); You will need to configure your web server to use `{project_dir}/{public_dir}/index.php` as your single entry point to your application; The Laravel docs have a good sample Nginx configuration that is a great starting place for configuring Nginx for the Front Controller pattern in PHP;
 
-Your `{project_dir}/{public_dir}/index.php` file should look something like this:
+Your `{project_dir}/{public_dir}/index.php` file should look something like this***:
+
+*** if you cloned the `PikaJew002/handrolled-project` repo, all the files mentioned here already exist; Nifty, eh?
 
 ```php
 // {project_dir}/{public_dir}/index.php
@@ -169,8 +175,8 @@ class UsersController
 
     public function view($id): Response
     {
-        $user = User::find($id);
-        if(empty($user)) {
+        $user = User::findById($id);
+        if(is_null($user)) {
             return new NotFoundResponse();
         }
         return new JsonResponse(['data' => $user]);
@@ -184,17 +190,13 @@ class UsersController
         $user->last_name = $request->input('last_name');
         $user->save();
 
-        return new JsonResponse([
-            'data' => [
-                'message' => 'success',
-            ],
-        ], 201);
+        return new JsonResponse(['user' => $user], 201);
     }
 
     public function destroy($id): Response
     {
-        $user = User::find($id);
-        if(empty($user)) {
+        $user = User::findById($id);
+        if(is_null($user)) {
             return new NotFoundResponse();
         }
         if($user->delete()) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
     "name": "pikajew002/handrolled",
-    "description": "A minimalist, bare-bones framework for small handrolled PHP projects",
+    "description": "A minimalist, bare-bones framework for building small, dope handrolled PHP projects",
+    "authors": [
+        {
+            "name": "Aaron Eisenberg",
+            "email": "aaron@ironmthome.com"
+        }
+    ],
     "require": {
         "php": ">=7.4",
         "illuminate/config": "^8.53",

--- a/src/Database/ORM/Entity.php
+++ b/src/Database/ORM/Entity.php
@@ -20,7 +20,7 @@ abstract class Entity
         return static::getContainer()->get(static::$connection);
     }
 
-    public static function morph(array $object): self
+    protected static function morph(array $object): self
     {
         $class = new ReflectionClass(get_called_class());
         $entity = $class->newInstance();
@@ -29,7 +29,6 @@ abstract class Entity
                 $prop->setValue($entity, $object[$prop->getName()]);
             }
         }
-        $entity->initialize();
 
         return $entity;
     }
@@ -38,38 +37,49 @@ abstract class Entity
      * @return Entity[]
      * @param $options = ["conditions" => [...], "order" => "..."]
      */
-    public static function find($options)
+    public static function find(array $options)
     {
         $db = static::getDbInstance();
         $tableName = static::getTableName();
-        $result = [];
-        $query = "SELECT * FROM `".$tableName."`";
+        $query = "SELECT * FROM $tableName";
+        $params = [];
         // options is array to parse into conditions/sort by
-        if(is_array($options) && !empty($options)) {
-            if(isset($options['conditions']) && !empty($options['conditions'])) {
-                $conditions = [];
-                foreach($options['conditions'] as $key => $value) {
-                    $conditions[] = "`".$key."` = \"".$value."\"";
-                }
-                $query .=" WHERE ".implode(" AND ", $conditions);
+        if(isset($options['conditions']) && !empty($options['conditions'])) {
+            $conditions = [];
+            foreach($options['conditions'] as $key => $value) {
+                $conditions[] = "$key = ?";
+                $params[] = $value;
             }
-            if(isset($options['order']) && !empty($options['order'])) {
-                $query .= " ORDER BY ".$options['order'];
-            }
+            $query .=" WHERE ".implode(" AND ", $conditions);
         }
-        // options is an id to retreive a single entity
-        else {
-            $query .=" WHERE `id` = \"".$options."\"";
+        if(isset($options['order']) && !empty($options['order'])) {
+            $query .= " ORDER BY {$options['order']}";
         }
-        $raw = $db->query($query);
-        if($db->errorCode() != 00000) {
-            throw new Exception($db->errorInfo()[2]);
-        }
+        $raw = $db->prepare($query);
+        $raw->execute($params);
+        $result = [];
         foreach($raw as $rawRow) {
             $result[] = static::morph($rawRow);
         }
 
         return $result;
+    }
+
+    /*
+     * @return Entity
+     * @param $options = ["conditions" => [...], "order" => "..."]
+     */
+    public static function findById($id): ?self
+    {
+        $db = static::getDbInstance();
+        $tableName = static::getTableName();
+        $query = "SELECT * FROM $tableName WHERE id = ?";
+        $raw = $db->prepare($query);
+        $raw->execute([$id]);
+        foreach($raw as $rawRow) {
+            return static::morph($rawRow);
+        }
+        return null;
     }
 
     /*
@@ -79,12 +89,8 @@ abstract class Entity
     {
         $db = static::getDbInstance();
         $tableName = static::getTableName();
+        $raw = $db->query("SELECT * FROM $tableName");
         $result = [];
-        $query = "SELECT * FROM `".$tableName."`";
-        $raw = $db->query($query);
-        if($db->errorCode() != 00000) {
-            throw new Exception($db->errorInfo()[2]);
-        }
         foreach($raw as $rawRow) {
             $result[] = static::morph($rawRow);
         }
@@ -92,51 +98,55 @@ abstract class Entity
         return $result;
     }
 
-    public function save()
+    public function save(): bool
     {
         $db = static::getDbInstance();
         $tableName = static::getTableName();
-        $class = new ReflectionClass($this);
-
+        $paramArray = [];
         $propsArray = [];
-        foreach($class->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+        foreach((new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
             $propName = $property->getName();
-            if($propName !== "id") {
-                var_dump($this->{$propName});
+            if($propName !== 'id') {
                 if(!empty($this->{$propName})) {
-                    $propsArray[] = "`".$propName."` = \"".$this->{$propName}."\"";
+                    $paramArray[] = $this->{$propName};
+                    $propsArray[] = "$propName = ?";
                 }
             }
         }
-        die(var_dump($propsArray));
-        $setClause = implode(", ", $propsArray);
-        $sqlQuery = "";
+        $setClause = implode(', ', $propsArray);
         if($this->id > 0) { // update query
-            $sqlQuery = "UPDATE `".$tableName."` SET ".$setClause." WHERE id = ".$this->id;
+            return $this->update($db, $tableName, $setClause, $paramArray);
         } else { // insery query
-            $sqlQuery = "INSERT INTO `".$tableName."` SET ".$setClause;
+            return $this->insert($db, $tableName, $setClause, $paramArray);
         }
-        $result = $db->exec($sqlQuery);
-        if($db->errorCode() != 00000) {
-            throw new Exception($db->errorInfo()[2]);
-        }
-
-        return $result;
     }
 
-    public function delete()
+    protected function update($db, string $tableName, string $setClause, array $params): bool
+    {
+        return $db->prepare("UPDATE $tableName SET $setClause, updated_at = NOW() WHERE id = ?")
+                  ->execute(array_merge($params, [$this->id]));
+    }
+
+    protected function insert($db, string $tableName, string $setClause, array $params): bool
+    {
+        $db->prepare("INSERT INTO $tableName SET $setClause")->execute($params);
+        if($this->id = $db->lastInsertId('id')) {
+            foreach($db->query("SELECT created_at, updated_at FROM $tableName WHERE id = {$this->id}") as $result) {
+                $this->created_at = $result['created_at'];
+                $this->updated_at = $result['updated_at'];
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public function delete(): bool
     {
         $db = static::getDbInstance();
         $tableName = static::getTableName();
-        $sqlQuery = "";
         if($this->id > 0) {
-            $sqlQuery = "DELETE FROM `".$tableName."` WHERE id = ".$this->id;
+            return $db->prepare("DELETE FROM $tableName WHERE id = ?")->execute([$this->id]);
         }
-        $result = $db->exec($sqlQuery);
-        if($db->errorCode() != 00000) {
-            throw new Exception($db->errorInfo()[2]);
-        }
-
-        return $result;
+        return false;
     }
 }

--- a/src/Database/ORM/Entity.php
+++ b/src/Database/ORM/Entity.php
@@ -4,6 +4,7 @@ namespace PikaJew002\Handrolled\Database\ORM;
 
 use Exception;
 use PikaJew002\Handrolled\Application\Application;
+use PikaJew002\Handrolled\Interfaces\Database;
 use PikaJew002\Handrolled\Traits\UsesContainer;
 use ReflectionClass;
 use ReflectionProperty;
@@ -12,9 +13,11 @@ abstract class Entity
 {
     use UsesContainer;
 
-    public static function getDbInstance()
+    protected static string $connection = Database::class;
+
+    public static function getDbInstance(): Database
     {
-        return static::getContainer()->get('db');
+        return static::getContainer()->get(static::$connection);
     }
 
     public static function morph(array $object): self


### PR DESCRIPTION
Updates for Entities/Models:

- Now use PDO::prepare and PDO::execute statements when appropriate to prevent SQL injection from occurring
- New function `Entity::findById($id)`  returns single entity that matches the id given or null
- After insert, instance `id` is updated/refreshed along with `created_at` and `updated_at` timestamps
- After update, instance `updated_at` timestamp updated
- By default they use the connection instance that is used by default, but this can now be overridden by defining a `protected static string $connection` property that is the fully qualified class name to the database implementation you want to use
- The string `PikaJew002\Handrolled\Interfaces\Database::class` will auto resolve to the default database implementation, you can define your own database implementation and under the config->database->{implementation-name}->class config value point to the NewDBImplementation::class string, and in the bootDatabase function pass in the name defined in `config/database.php` to use that by default

Application/Container:

- Database interface is aliased to default database implementation now instead of 'db', this is the same for Request class and 'request' alias