### PR TITLE
Fix: using PHP 8.0 feat ::class -> get_class(), check for cookies set

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -12,7 +12,7 @@ class Manager
 
     public function __construct(User $user, Configuration $config)
     {
-        $this->userClass = $user::class;
+        $this->userClass = get_class($user);
         $this->config = $config;
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -120,14 +120,19 @@ class Request
 
     protected function parseCookies(array $headers): array
     {
-        $cookies = [];
+        $cookiesFromHeaders = [];
+        $cookiesFromHeadersStr = isset($headers['COOKIE']) ? $headers['COOKIE'] : '';
+        $headerCookieArr = $cookiesFromHeadersStr !== '' ? explode(';', $cookiesFromHeadersStr) : [];
         $headerCookieArr = explode(';', (isset($headers['COOKIE']) ? $headers['COOKIE'] : ''));
         foreach($headerCookieArr as $cookieRaw) {
+            if($cookieRaw === '') continue;
             $cookieParsed = explode('=', $cookieRaw);
-            $cookies[$cookieParsed[0]] = $cookieParsed[1];
+            if(isset($cookieParsed[0]) && isset($cookieParsed[1])) {
+                $cookiesFromHeaders[$cookieParsed[0]] = $cookieParsed[1];
+            }
         }
-
-        return $cookies + (isset($_COOKIES) ? $_COOKIES : []);
+        
+        return $cookiesFromHeaders + (isset($_COOKIES) ? $_COOKIES : []);
     }
 
     public function getMethod(): string

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -95,7 +95,7 @@ class Route
                 $controllerParams[] = $param->getDefaultValue();
                 continue;
             }
-            if($param->getType()->getName() === $request::class) {
+            if($param->getType()->getName() === get_class($request)) {
                 $controllerParams[] = $request;
                 continue;
             }


### PR DESCRIPTION
Bug fixes:

- Was using PHP 8.0 feature (not available in PHP 7.4) `$object::class`, switched to `get_class($object)` which is equivalent
- Extracting cookies from $_SERVER['HTTP_COOKIE'] gave error if string was malformed

Update to v0.3.1 for PHP version compatibility